### PR TITLE
Display loader after an optionnal delay

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -1,17 +1,20 @@
 var ctrl;
 var showTimeout;
+var message;
 
 function show(_message, _cancelable, _delay) {
 
+    message = _message;
+
     if (ctrl && ctrl.hasFocus) {
-        ctrl.update(_message, _cancelable);
+        ctrl.update(message, _cancelable);
         return;
     }
     
     if (_delay) {
         if (!showTimeout) {
             showTimeout = setTimeout(function () {
-                show(_message, _cancelable);
+                show(message, _cancelable);
             }, _delay);
         }
         return;
@@ -23,7 +26,7 @@ function show(_message, _cancelable, _delay) {
     }
 
     var newCtrl = Widget.createController('window', {
-        message: _message,
+        message: message,
         cancelable: _cancelable
     });
 

--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -1,10 +1,25 @@
 var ctrl;
+var showTimeout;
 
-function show(_message, _cancelable) {
+function show(_message, _cancelable, _delay) {
 
     if (ctrl && ctrl.hasFocus) {
         ctrl.update(_message, _cancelable);
         return;
+    }
+    
+    if (_delay) {
+        if (!showTimeout) {
+            showTimeout = setTimeout(function () {
+                show(_message, _cancelable);
+            }, _delay);
+        }
+        return;
+    }
+    
+    if (showTimeout) {
+        clearTimeout(showTimeout);
+        showTimeout = null;
     }
 
     var newCtrl = Widget.createController('window', {
@@ -22,7 +37,10 @@ function show(_message, _cancelable) {
 }
 
 function hide() {
-    
+    if (showTimeout) {
+        clearTimeout(showTimeout);
+        showTimeout = null;
+    }
     if (ctrl) {
         ctrl.close();
         ctrl = null;


### PR DESCRIPTION
It prevent loader flicks when the display duration is very short by delaying the displaying and cancelling delay if hide during this delay