### PR TITLE
Remove deprecated style

### DIFF
--- a/styles/view.tss
+++ b/styles/view.tss
@@ -28,10 +28,6 @@
   style: Ti.UI.ActivityIndicatorStyle.BIG
 }
 
-".loadingIndicator[platform=ios]": {
-  style: Ti.UI.iPhone.ActivityIndicatorStyle.BIG
-}
-
 ".loadingImages": {
   top: '0dp',
   images: [


### PR DESCRIPTION
in 5.1. Titanium.UI.iPhone.ActivityIndicatorStyle is deprecated 